### PR TITLE
fix: align icon and text in Join Discussions button

### DIFF
--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -281,7 +281,7 @@ export const LoadingButton: React.FC<LoadingButtonProps> = ({
     >
       <div className="flex items-center justify-center space-x-2">
         {isLoading && <Spinner size={spinnerSize} />}
-        <span>{children}</span>
+        {children}
       </div>
     </button>
   );


### PR DESCRIPTION
## 📋 Description
Fixed the misalignment of the icon and text in the "Join Discussions" 
button on the Roadmap page.

## 🐛 Problem
The social icon and the "Join Discussions" text were not aligned on 
the same line. This was caused by a redundant `<span>` wrapper around 
`{children}` inside the `LoadingButton` component in `Spinner.tsx`. 
Since the `<span>` lacked flex properties, the icon and text were 
treated as inline elements and aligned poorly.

## ✅ Fix
Removed the redundant `<span>` wrapper from around `{children}` in 
the `LoadingButton` component. The icon and text are now direct 
children of the flex container (`flex items-center justify-center 
space-x-2`), ensuring they stay perfectly centered on a single line.

## 📁 Files Changed
- `src/components/Spinner.tsx`

## 📸 Screenshots
- Before
<img width="230" height="106" alt="Screenshot 2026-03-27 at 8 23 00 PM" src="https://github.com/user-attachments/assets/cd959b8b-a130-42ae-b59a-9a3749458829" />

- After
<img width="264" height="76" alt="Screenshot 2026-03-27 at 8 23 48 PM" src="https://github.com/user-attachments/assets/fc197e73-9565-4cbc-b864-608abedb185b" />


| Icon and text misaligned / stacking | Icon and text on same line ✅ |

## 🔗 Related Issue
Closes #52 